### PR TITLE
Icepay ideal flow

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include pretix_icepay/static *.js
+recursive-include pretix_icepay/templates *.html

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -90,7 +90,11 @@ class Icepay(BasePaymentProvider):
     #
     def checkout_confirm_render(self, request) -> str:
         template = get_template('icepay/checkout_payment_confirm.html')
-        ctx = {'request': request, 'event': self.event, 'settings': self.settings}
+        ctx = {
+            'bank_name': IDEAL_BANKS[request.session['payment_icepay_issuer']],
+            'request': request,
+            'event': self.event,
+            'settings': self.settings}
         return template.render(ctx)
     #
     # def order_can_retry(self, order):

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -79,19 +79,6 @@ class Icepay(BasePaymentProvider):
     def order_prepare(self, request, order):
         return self.checkout_prepare(request, None)
 
-    def checkout_prepare(self, request, cart):
-        # raise Exception(cart)
-        # token = request.POST.get('stripe_token', '')
-        #request.session['payment_stripe_token'] = token
-        #request.session['payment_icepay_bank'] = request.POST.get('payment_icepay_bank', '')
-    #     request.session['payment_stripe_last4'] = request.POST.get('stripe_card_last4', '')
-    #     if token == '':
-    #         messages.error(request, _('You may need to enable JavaScript for Stripe payments.'))
-    #         return False
-        return True
-
-
-
     # def payment_form_render(self, request) -> str:
     #     ui = self.settings.get('ui', default='pretix')
     #     # if ui == 'checkout':

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -17,8 +17,6 @@ from pretix.multidomain.urlreverse import build_absolute_uri
 
 logger = logging.getLogger('pretix_icepay')
 
-PAYMENT_OPTIONS = []
-
 IDEAL_BANKS = {  # Code : Display name
     'ABNAMRO': 'ABN AMRO',
     'ASNBANK': 'ASN Bank',
@@ -100,8 +98,6 @@ class Icepay(BasePaymentProvider):
         merchant_id = self.settings.get('merchant_id')
         secret = self.settings.get('secret_code')
         client = IcepayClient(merchant_id, secret)
-        if not PAYMENT_OPTIONS:
-            PAYMENT_OPTIONS.extend(client.GetMyPaymentMethods())
         return client
 
     def payment_perform(self, request, order) -> str:

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -6,6 +6,7 @@ from icepay import IcepayClient
 
 from django import forms
 from django.contrib import messages
+from django.shortcuts import redirect
 from django.template.loader import get_template
 from django.utils.translation import ugettext_lazy as _
 
@@ -13,7 +14,7 @@ from pretix.base.models import Quota
 from pretix.base.payment import BasePaymentProvider
 from pretix.base.services.mail import SendMailException
 from pretix.base.services.orders import mark_order_paid, mark_order_refunded
-from pretix.multidomain.urlreverse import build_absolute_uri
+from pretix.multidomain.urlreverse import eventreverse, build_absolute_uri
 
 from requests import HTTPError
 
@@ -96,9 +97,9 @@ class Icepay(BasePaymentProvider):
             'event': self.event,
             'settings': self.settings}
         return template.render(ctx)
-    #
-    # def order_can_retry(self, order):
-    #     return True
+
+    def order_can_retry(self, order):
+        return True
 
     def get_client(self):
         """Returns an IcepayClient configured with the event's credentials."""
@@ -133,16 +134,10 @@ class Icepay(BasePaymentProvider):
         else:
             return response['PaymentScreenURL']
 
-    # def order_pending_render(self, request, order) -> str:
-    #     if order.payment_info:
-    #         payment_info = json.loads(order.payment_info)
-    #     else:
-    #         payment_info = None
-    #     template = get_template('icepay/pending.html')
-    #     ctx = {'request': request, 'event': self.event, 'settings': self.settings,
-    #            'order': order, 'payment_info': payment_info}
-    #     return template.render(ctx)
-    #
+    def order_pending_render(self, request, order) -> str:
+        template = get_template('icepay/pending.html')
+        return template.render()
+
     # def order_control_render(self, request, order) -> str:
     #     if order.payment_info:
     #         payment_info = json.loads(order.payment_info)

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -100,14 +100,14 @@ class Icepay(BasePaymentProvider):
     # def order_can_retry(self, order):
     #     return True
 
-    def _icepay(self):
-        merchant_id = self.settings.get('merchant_id')
-        secret = self.settings.get('secret_code')
-        client = IcepayClient(merchant_id, secret)
-        return client
+    def get_client(self):
+        """Returns an IcepayClient configured with the event's credentials."""
+        return IcepayClient(
+            self.settings.get('merchant_id'),
+            self.settings.get('secret_code'))
 
     def payment_perform(self, request, order) -> str:
-        client = self._icepay()
+        client = self.get_client()
         result_url = build_absolute_uri(
             request.event, 'plugins:pretix_icepay:result')
         checkout_params = {

--- a/pretix_icepay/payment.py
+++ b/pretix_icepay/payment.py
@@ -20,17 +20,18 @@ logger = logging.getLogger('pretix_icepay')
 PAYMENT_OPTIONS = []
 
 IDEAL_BANKS = {  # Code : Display name
-    'ABNAMRO': 'ABNAMRO',
-    'ASNBANK': 'ASNBANK',
-    'BUNQ': 'BUNQ',
+    'ABNAMRO': 'ABN AMRO',
+    'ASNBANK': 'ASN Bank',
+    'BUNQ': 'Bunq',
     'ING': 'ING',
-    'KNAB': 'KNAB',
-    'RABOBANK': 'RABOBANK',
-    'SNSBANK': 'SNSBANK',
-    'SNSREGIOBANK':'SNSREGIOBANK',
-    'TRIODOSBANK': 'TRIODOSBANK',
-    'VANLANSCHOT': 'VANLANSCHOT'
+    'KNAB': 'Knab',
+    'RABOBANK': 'Rabobank',
+    'SNSBANK': 'SNS Bank',
+    'SNSREGIOBANK':'RegioBank',
+    'TRIODOSBANK': 'Triodos Bank',
+    'VANLANSCHOT': 'van Lanshot'
 }
+
 
 class Icepay(BasePaymentProvider):
     identifier = 'icepay'

--- a/pretix_icepay/signals.py
+++ b/pretix_icepay/signals.py
@@ -55,4 +55,4 @@ def pretixcontrol_logentry_display(sender, logentry, **kwargs):
         text = _('Dispute closed. Status: {}').format(data['data']['object']['status'])
 
     if text:
-        return _('Stripe reported an event: {}').format(text)
+        return _('ICEPAY reported an event: {}').format(text)

--- a/pretix_icepay/templates/icepay/checkout_payment_confirm.html
+++ b/pretix_icepay/templates/icepay/checkout_payment_confirm.html
@@ -1,12 +1,9 @@
 {% load i18n %}
 
 <p>{% blocktrans trimmed %}
-    The total amount will be withdrawn from your account.
+    Upon confirming your order, you will be redirected to our payment provider. Please follow the instructions provided.
 {% endblocktrans %}</p>
 <dl class="dl-horizontal">
-    <dt>{% trans "Card type" %}</dt>
-    <dd>{{ request.session.payment_icepay_brand }}</dd>
-    <dt>{% trans "Card number" %}</dt>
-    <dd>**** **** **** {{ request.session.payment_icepay_last4 }}</dd>
+    <dt>{% trans "Selected bank" %}</dt>
+    <dd>{{ bank_name }}</dd>
 </dl>
-

--- a/pretix_icepay/templates/icepay/pending.html
+++ b/pretix_icepay/templates/icepay/pending.html
@@ -1,12 +1,6 @@
 {% load i18n %}
 
 <p>{% blocktrans trimmed %}
-    The credit card transaction could not be completed for the following reason:
+    You've not yet paid for your order, please complete the payment process.
 {% endblocktrans %}
-    <br />
-    {% if payment_info and payment_info.error %}
-        {{ payment_info.message }}
-    {% else %}
-        {% trans "Unknown reason" %}
-    {% endif %}
 </p>

--- a/pretix_icepay/urls.py
+++ b/pretix_icepay/urls.py
@@ -1,9 +1,14 @@
-from django.conf.urls import include, url
+from django.conf.urls import (
+    include,
+    url)
 
-from .views import webhook
+from .views import (
+    result,
+    webhook)
 
 event_patterns = [
     url(r'^icepay/', include([
+        url(r'^result/$', result, name='result'),
         url(r'^webhook/$', webhook, name='webhook'),
     ])),
 ]

--- a/pretix_icepay/views.py
+++ b/pretix_icepay/views.py
@@ -32,7 +32,7 @@ def result(request, *args, **kwargs):
 
     # Valid postback, and thus ICEPAY response:
     status = request.GET.get('Status')
-    order = Order.objects.get(pk=request.GET['OrderID'])
+    order = Order.objects.get(code=request.GET['Reference'])
     if status == 'OK':
         try:
             mark_order_paid(order, 'icepay')

--- a/pretix_icepay/views.py
+++ b/pretix_icepay/views.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('pretix_icepay')
 def result(request, *args, **kwargs):
     """Handle ICEPAY result after the user comes back from the payment page."""
     provider = Icepay(request.event)
-    client = provider._icepay()
+    client = provider.get_client()
     try:
         client.validate_postback(request.GET)
     except AssertionError:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'git+https://github.com/edelooff/icepay-python.git#egg=icepay-python',
     ],
     packages=['pretix_icepay'],
+    include_package_data=True,
     install_requires=['icepay_python'],
     url='https://github.com/chotee/pretix-icepay',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,16 @@ from setuptools import setup
 
 setup(
     name='pretix-icepay',
-    version="0.0.1",
-    description="Pretix extension for the Icepay payment provider.",
+    version='0.0.1',
+    description='Pretix extension for the Icepay payment provider.',
     author='chotee',
     author_email='chotee@openended.eu',
+    dependency_links=[
+        'git+https://github.com/edelooff/icepay-python.git#egg=icepay-python',
+    ],
     packages=['pretix_icepay'],
     install_requires=['icepay_python'],
-    url="https://github.com/chotee/pretix-icepay",
-    entry_points="""
-[pretix.plugin]
-pretix_icepay=pretix_icepay:PretixPluginMeta
-"""
+    url='https://github.com/chotee/pretix-icepay',
+    entry_points={
+        'pretix.plugin': 'pretix_icepay = pretix_icepay:PretixPluginMeta'}
 )


### PR DESCRIPTION
Work-in-progress branch to make things work (better):

Performing a payment actually triggers a redirect to the ICEPAY website where the customer performs (or not) a payment, upon which they're redirected to the result view. This view *should* then mark the order as paid and redirect the user to the appropriate page.

Also touches up some strings that mention other providers.

Result view and webhook (where required?) still need looking at, as do some of the templates that cause credit card stuff to render on the order confirmation page. Also, no idea whether an order can be paid after an initial failure. Things to work out.