### PR TITLE
Accept webhook as HTTP GET

### DIFF
--- a/pretix_icepay/views.py
+++ b/pretix_icepay/views.py
@@ -55,7 +55,6 @@ def success(request, *args, **kwargs):
 
 
 @csrf_exempt
-@require_POST
 @event_view(require_live=False)
 def webhook(request, *args, **kwargs):
     """Handle ICEPAY postbacks to update order payment status."""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pretix-icepay',
-    version='0.0.1',
+    version='0.0.2',
     description='Pretix extension for the Icepay payment provider.',
     author='chotee',
     author_email='chotee@openended.eu',


### PR DESCRIPTION
Updates the `webhook` view to accept requests with a method GET. ICEPAY uses this to (at the least) verify the existance of the path, possibly also to send updates that way. Processing code was already dual-method, so this needs no further work in that area.